### PR TITLE
PM-540 - Zk validator results from cassandra

### DIFF
--- a/tests/test_aws_keyspaces_client.py
+++ b/tests/test_aws_keyspaces_client.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+from uptime_service_validation.coordinator.aws_keyspaces_client import (
+    AWSKeyspacesClient,
+)
+
+
+def test_get_submitted_at_date_list():
+    start = datetime(2023, 11, 6, 15, 35, 47, 630499)
+    end = datetime(2023, 11, 6, 15, 45, 47, 630499)
+    result = AWSKeyspacesClient.get_submitted_at_date_list(start, end)
+    assert result == ["2023-11-06"]
+
+    start = datetime(2023, 11, 6, 15, 35, 47, 630499)
+    end = datetime(2023, 11, 7, 11, 45, 47)
+    result = AWSKeyspacesClient.get_submitted_at_date_list(start, end)
+    assert result == ["2023-11-06", "2023-11-07"]
+
+    start = datetime(2023, 11, 6, 15, 35, 47, 630499)
+    end = datetime(2023, 11, 8, 0, 0, 0)
+    result = AWSKeyspacesClient.get_submitted_at_date_list(start, end)
+    assert result == ["2023-11-06", "2023-11-07", "2023-11-08"]

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -1,6 +1,8 @@
 from datetime import datetime, timedelta
-from uptime_service_validation.coordinator.helper import pullFileNames, getTimeBatches
-import pytest
+from uptime_service_validation.coordinator.helper import (
+    pullFileNames,
+    getTimeBatches,
+)
 
 # The folloiwng two tests will fail as I have not given an accurate bucket name.
 # def testFilePullSmallRange(self):

--- a/uptime_service_validation/coordinator/coordinator.py
+++ b/uptime_service_validation/coordinator/coordinator.py
@@ -83,6 +83,8 @@ def main():
                 submissions = cassandra.get_submissions(
                     submitted_at_start=prev_batch_end,
                     submitted_at_end=cur_batch_end,
+                    start_inclusive=True,
+                    end_inclusive=False,
                 )
             finally:
                 cassandra.close()


### PR DESCRIPTION
This pr:
 - gathers submissions from AWS Keyspaces db using timerange provided by coordinator
 - the query that gets submissions is inclusive on start date and NOT inclusive on end date, as the end date becomes start date on subsequent operation (however it can be easily parametrized if needed otherwise)
 - introduces improvements in `AWSKeyspaceclient.get_submissions()`:
   - automatically accounting for partitining in the query by `submitted_at_date` when providing `submitted_at` range 
   - parametrizing on inclusivity on `submitted_at_start` and `submitted_at_end`