### PR TITLE
PM-745 Make program runnable in non-Kubernetes environment (setUpValidatorProcesses)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -690,6 +690,17 @@ files = [
 ]
 
 [[package]]
+name = "invoke"
+version = "2.2.0"
+description = "Pythonic task execution"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "invoke-2.2.0-py3-none-any.whl", hash = "sha256:6ea924cc53d4f78e3d98bc436b08069a03077e6f85ad1ddaa8a116d7dad15820"},
+    {file = "invoke-2.2.0.tar.gz", hash = "sha256:ee6cbb101af1a859c7fe84f2a264c059020b0cb7fe3535f9424300ab568f6bd5"},
+]
+
+[[package]]
 name = "jmespath"
 version = "1.0.1"
 description = "JSON Matching Expressions"
@@ -1666,4 +1677,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.13"
-content-hash = "c8f0b29967ffe56b9d37b293c5908f485305b4d21f92fbb3471559d5ee7c28be"
+content-hash = "ddcd2437cffe86cf18288bdf0fda44510b0273f4282b3798cc1e55e8ff6665af"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ networkx = "^3.2.1"
 matplotlib = "^3.8.1"
 psycopg2 = "^2.9.9"
 cassandra-driver = "^3.28.0"
+invoke = "^2.2.0"
 
 [tool.poetry.scripts]
 start = "uptime_service_validation.coordinator.coordinator:main"

--- a/tasks.py
+++ b/tasks.py
@@ -1,0 +1,108 @@
+from datetime import datetime, timedelta, timezone
+from invoke import task
+import os
+import psycopg2
+from psycopg2 import sql
+
+
+@task
+def create_database(ctx):
+    db_host = os.environ.get("POSTGRES_HOST")
+    db_port = os.environ.get("POSTGRES_PORT")
+    db_name = os.environ.get("POSTGRES_DB")
+    db_user = os.environ.get("POSTGRES_USER")
+    db_password = os.environ.get("POSTGRES_PASSWORD")
+
+    # Establishing connection to PostgreSQL server
+    conn = psycopg2.connect(
+        host=db_host, port=db_port, user=db_user, password=db_password
+    )
+    conn.autocommit = True
+    cursor = conn.cursor()
+
+    # Creating the database
+    try:
+        cursor.execute(sql.SQL("CREATE DATABASE {}").format(sql.Identifier(db_name)))
+        print(f"Database {db_name} created successfully")
+    except psycopg2.errors.DuplicateDatabase:
+        print(f"Database {db_name} already exists")
+
+    cursor.close()
+    conn.close()
+
+    # Connect to the new database
+    conn = psycopg2.connect(
+        host=db_host, port=db_port, dbname=db_name, user=db_user, password=db_password
+    )
+    conn.autocommit = True
+    cursor = conn.cursor()
+
+    # Path to the SQL script relative to tasks.py
+    sql_script_path = "uptime_service_validation/database/createDB.sql"
+
+    # Running the SQL script file
+    with open(sql_script_path, "r") as file:
+        sql_script = file.read()
+        cursor.execute(sql_script)
+        print("Database setup completed successfully")
+
+    cursor.close()
+    conn.close()
+
+
+@task
+def init_database(ctx, batch_end_epoch=None, mins_ago=None, override_empty=False):
+    db_host = os.environ.get("POSTGRES_HOST")
+    db_port = os.environ.get("POSTGRES_PORT")
+    db_name = os.environ.get("POSTGRES_DB")
+    db_user = os.environ.get("POSTGRES_USER")
+    db_password = os.environ.get("POSTGRES_PASSWORD")
+
+    conn = psycopg2.connect(
+        host=db_host, port=db_port, dbname=db_name, user=db_user, password=db_password
+    )
+    cursor = conn.cursor()
+
+    if mins_ago is not None:
+        batch_end_epoch = (
+            datetime.now(timezone.utc) - timedelta(minutes=int(mins_ago))
+        ).timestamp()
+    elif batch_end_epoch is None:
+        batch_end_epoch = datetime.now(timezone.utc).timestamp()
+    else:
+        batch_end_epoch = int(batch_end_epoch)
+
+    # Check if the table is empty, if override_empty is False
+    should_insert = True
+    if not override_empty:
+        cursor.execute("SELECT COUNT(*) FROM bot_logs")
+        count = cursor.fetchone()[0]
+        should_insert = count == 0
+
+    if should_insert:
+        processing_time = 0
+        files_processed = 0
+        file_timestamps = datetime.fromtimestamp(batch_end_epoch, timezone.utc)
+        batch_start_epoch = batch_end_epoch
+
+        # Inserting data into the bot_logs table
+        cursor.execute(
+            "INSERT INTO bot_logs (processing_time, files_processed, file_timestamps, batch_start_epoch, batch_end_epoch) \
+            VALUES (%s, %s, %s, %s, %s)",
+            (
+                processing_time,
+                files_processed,
+                file_timestamps,
+                batch_start_epoch,
+                batch_end_epoch,
+            ),
+        )
+        print(f"Row inserted into bot_logs table. batch_end_epoch: {batch_end_epoch}.")
+    else:
+        print(
+            "Table bot_logs is not empty. Row not inserted. You can override this by passing --override-empty."
+        )
+
+    conn.commit()
+    cursor.close()
+    conn.close()

--- a/uptime_service_validation/coordinator/coordinator.py
+++ b/uptime_service_validation/coordinator/coordinator.py
@@ -20,7 +20,7 @@ from uptime_service_validation.coordinator.aws_keyspaces_client import (
 
 
 def test_env():
-    test = os.environ["TEST_ENV"]
+    test = os.environ.get("TEST_ENV")
     if test == "1":
         return True
     else:

--- a/uptime_service_validation/coordinator/coordinator.py
+++ b/uptime_service_validation/coordinator/coordinator.py
@@ -18,6 +18,10 @@ from uptime_service_validation.coordinator.aws_keyspaces_client import (
     AWSKeyspacesClient,
 )
 
+# Add project root to python path
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+sys.path.insert(0, project_root)
+
 
 def test_env():
     test = os.environ.get("TEST_ENV")
@@ -28,6 +32,7 @@ def test_env():
 
 
 def main():
+    process_loop_count = 0
     load_dotenv()
 
     logging.basicConfig(
@@ -80,7 +85,7 @@ def main():
             start = time()
             jobs = []
             if test_env():
-                logging.warn("running in test environment")
+                logging.warning("running in test environment")
                 setUpValidatorProcesses(
                     time_intervals, logging, worker_image, worker_tag
                 )
@@ -109,6 +114,16 @@ def main():
                 cassandra.close()
 
             logging.info("number of submissions: {0}".format(len(submissions)))
+            # print("submitter, state_hash, parent, height, slot, validation_error")
+            # for s in submissions:
+            #     print(
+            #         s.submitter,
+            #         s.state_hash,
+            #         s.parent,
+            #         s.height,
+            #         s.slot,
+            #         s.validation_error,
+            #     )
 
             # Step 5 checks for forks and writes to the db.
             state_hash_df = pd.DataFrame(
@@ -223,10 +238,12 @@ def main():
                         cur_batch_end.timestamp(),
                         end - start,
                     )
-                    bot_log_id = createBotLog(connection, values)
+                    bot_log_id = createBotLog(connection, logging, values)
 
                     shortlisted_state_hash_df["bot_log_id"] = bot_log_id
-                    insertStatehashResults(shortlisted_state_hash_df)
+                    insertStatehashResults(
+                        connection, logging, shortlisted_state_hash_df
+                    )
 
                     if not point_record_df.empty:
                         point_record_df["amount"] = 1
@@ -246,7 +263,7 @@ def main():
                             ]
                         ]
 
-                        createPointRecord(connection, point_record_df)
+                        createPointRecord(connection, logging, point_record_df)
                 except Exception as error:
                     connection.rollback()
                     logging.error(ERROR.format(error))
@@ -259,7 +276,10 @@ def main():
                 logging.info("Finished processing data from table.")
             try:
                 updateScoreboard(
-                    connection, cur_batch_end, int(os.environ["UPTIME_DAYS_FOR_SCORE"])
+                    connection,
+                    logging,
+                    cur_batch_end,
+                    int(os.environ["UPTIME_DAYS_FOR_SCORE"]),
                 )
             except Exception as error:
                 connection.rollback()

--- a/uptime_service_validation/coordinator/coordinator.py
+++ b/uptime_service_validation/coordinator/coordinator.py
@@ -197,7 +197,7 @@ def main():
                     graph=weighted_graph,
                     queue_list=queue_list,
                     node=queue_list[0],
-                    batch_statehash=batch_state_hash,
+                    # batch_statehash=batch_state_hash, (this used to be here in old code, but it's not used anywhere inside the function)
                 )
                 point_record_df = master_df[
                     master_df["state_hash"].isin(

--- a/uptime_service_validation/coordinator/helper.py
+++ b/uptime_service_validation/coordinator/helper.py
@@ -12,7 +12,13 @@ ERROR = "Error: {0}"
 
 # utility function to create row in bot_logs table if it is empty
 def add_row_to_bot_logs_if_empty(
-    conn, logger, processing_time, files_processed, batch_start_epoch, batch_end_epoch
+    conn,
+    logger,
+    processing_time,
+    files_processed,
+    batch_start_epoch,
+    batch_end_epoch,
+    override_if_empty=False,
 ):
     try:
         cursor = conn.cursor()
@@ -20,7 +26,7 @@ def add_row_to_bot_logs_if_empty(
         result = cursor.fetchone()
         count = result[0]
 
-        if count == 0:
+        if count == 0 or override_if_empty:
             batch_end_dt = datetime.fromtimestamp(batch_end_epoch, timezone.utc)
 
             cursor.execute(
@@ -423,6 +429,6 @@ if __name__ == "__main__":
         user=os.environ["POSTGRES_USER"],
         password=os.environ["POSTGRES_PASSWORD"],
     )
-    timestamp = datetime.now().timestamp()
+    # timestamp = datetime.now().timestamp()
     timestamp = datetime(2023, 11, 14, 14, 35, 47).timestamp()
     add_row_to_bot_logs_if_empty(connection, logging, 0, 0, timestamp, timestamp)

--- a/uptime_service_validation/coordinator/helper.py
+++ b/uptime_service_validation/coordinator/helper.py
@@ -122,7 +122,7 @@ def findNewValuesToInsert(existing_values, new_values):
     return (
         existing_values.merge(new_values, how="outer", indicator=True)
         .loc[lambda x: x["_merge"] == "right_only"]
-        .drop("_merge", 1)
+        .drop("_merge", axis=1)
         .drop_duplicates()
     )
 
@@ -136,6 +136,7 @@ def createStatehash(conn, logger, statehash_df, page_size=100):
     try:
         cursor = conn.cursor()
         extras.execute_batch(cursor, query, tuples, page_size)
+        conn.commit()
     except (Exception, psycopg2.DatabaseError) as error:
         logger.error(ERROR.format(error))
         cursor.close()

--- a/uptime_service_validation/coordinator/helper.py
+++ b/uptime_service_validation/coordinator/helper.py
@@ -259,7 +259,7 @@ def getMinimumWeight(graph, child_node):
     return child_node_weight
 
 
-def bfs(graph, queue_list, node, max_depth=2):
+def bfs(graph, queue_list, node, batch_statehash, max_depth=2):
     visited = list()
     visited.append(node)
     cnt = 2
@@ -307,7 +307,7 @@ def createBotLog(conn, logger, values):
 def insertStatehashResults(conn, logger, df, page_size=100):
     temp_df = df[["parent_state_hash", "state_hash", "weight", "bot_log_id"]]
     tuples = [tuple(x) for x in temp_df.to_numpy()]
-    query = """INSERT INTO bot_logs_statehash(parent_statehash_id, statehash_id, weight, bot_log_id ) 
+    query = """INSERT INTO botlogs_statehash(parent_statehash_id, statehash_id, weight, bot_log_id ) 
         VALUES ( (SELECT id FROM statehash WHERE value= %s), (SELECT id FROM statehash WHERE value= %s), %s, %s ) """
     cursor = conn.cursor()
 
@@ -319,7 +319,7 @@ def insertStatehashResults(conn, logger, df, page_size=100):
         return 1
     finally:
         cursor.close()
-    logger.info("create_bot_logs_statehash  end ")
+    logger.info("create_botlogs_statehash  end ")
     return 0
 
 

--- a/uptime_service_validation/coordinator/helper.py
+++ b/uptime_service_validation/coordinator/helper.py
@@ -8,7 +8,7 @@ import networkx as nx
 ERROR = "Error: {0}"
 
 
-def getTimeBatches(start_time, end_time, range_number):
+def getTimeBatches(start_time: datetime, end_time: datetime, range_number: int):
     diff = (end_time - start_time) / range_number
     print(diff)
     time_intervals = []
@@ -366,3 +366,10 @@ def getExistingNodes(conn, logger):
     finally:
         cursor.close()
     return nodes
+
+
+if __name__ == "__main__":
+    a = datetime(2023, 11, 6, 15, 35, 47, 630499)
+    b = a + timedelta(minutes=5)
+    result = getTimeBatches(a, b, 10)
+    print(result)

--- a/uptime_service_validation/coordinator/helper.py
+++ b/uptime_service_validation/coordinator/helper.py
@@ -1,4 +1,3 @@
-import os
 import psycopg2
 import psycopg2.extras as extras
 import matplotlib.pyplot as plt
@@ -8,48 +7,6 @@ import networkx as nx
 
 
 ERROR = "Error: {0}"
-
-
-# utility function to create row in bot_logs table if it is empty
-def add_row_to_bot_logs_if_empty(
-    conn,
-    logger,
-    processing_time,
-    files_processed,
-    batch_start_epoch,
-    batch_end_epoch,
-    override_if_empty=False,
-):
-    try:
-        cursor = conn.cursor()
-        cursor.execute("SELECT COUNT(*) FROM bot_logs")
-        result = cursor.fetchone()
-        count = result[0]
-
-        if count == 0 or override_if_empty:
-            batch_end_dt = datetime.fromtimestamp(batch_end_epoch, timezone.utc)
-
-            cursor.execute(
-                "INSERT INTO bot_logs (processing_time, files_processed, file_timestamps, batch_start_epoch, batch_end_epoch) \
-                VALUES (%s, %s, %s, %s, %s)",
-                (
-                    processing_time,
-                    files_processed,
-                    batch_end_dt,
-                    batch_start_epoch,
-                    batch_end_epoch,
-                ),
-            )
-
-            conn.commit()
-
-            logger.info("Initial row added successfully.")
-    except (Exception, psycopg2.DatabaseError) as error:
-        logger.error(ERROR.format(error))
-        return -1
-    finally:
-        if cursor is not None:
-            cursor.close()
 
 
 def getTimeBatches(start_time: datetime, end_time: datetime, range_number: int):
@@ -410,25 +367,3 @@ def getExistingNodes(conn, logger):
     finally:
         cursor.close()
     return nodes
-
-
-if __name__ == "__main__":
-    import logging
-    import sys
-
-    logging.basicConfig(
-        stream=sys.stdout,
-        level=logging.INFO,
-        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-    )
-
-    connection = psycopg2.connect(
-        host=os.environ["POSTGRES_HOST"],
-        port=os.environ["POSTGRES_PORT"],
-        database=os.environ["POSTGRES_DB"],
-        user=os.environ["POSTGRES_USER"],
-        password=os.environ["POSTGRES_PASSWORD"],
-    )
-    # timestamp = datetime.now().timestamp()
-    timestamp = datetime(2023, 11, 14, 14, 35, 47).timestamp()
-    add_row_to_bot_logs_if_empty(connection, logging, 0, 0, timestamp, timestamp)

--- a/uptime_service_validation/coordinator/helper.py
+++ b/uptime_service_validation/coordinator/helper.py
@@ -79,7 +79,7 @@ def getPreviousStatehash(conn, logger, bot_log_id):
     cursor = conn.cursor()
     try:
         sql_query = """select  ps.value parent_statehash, s1.value statehash, b.weight
-            from bot_logs_statehash b join statehash s1 ON s1.id = b.statehash_id 
+            from botlogs_statehash b join statehash s1 ON s1.id = b.statehash_id 
 		    join statehash ps on b.parent_statehash_id = ps.id where bot_log_id =%s"""
         cursor.execute(sql_query, (bot_log_id,))
         result = cursor.fetchall()
@@ -136,7 +136,6 @@ def createStatehash(conn, logger, statehash_df, page_size=100):
     try:
         cursor = conn.cursor()
         extras.execute_batch(cursor, query, tuples, page_size)
-        conn.commit()
     except (Exception, psycopg2.DatabaseError) as error:
         logger.error(ERROR.format(error))
         cursor.close()

--- a/uptime_service_validation/coordinator/helper.py
+++ b/uptime_service_validation/coordinator/helper.py
@@ -259,7 +259,7 @@ def getMinimumWeight(graph, child_node):
     return child_node_weight
 
 
-def bfs(graph, queue_list, node, batch_statehash, max_depth=2):
+def bfs(graph, queue_list, node, max_depth=2):
     visited = list()
     visited.append(node)
     cnt = 2

--- a/uptime_service_validation/coordinator/helper.py
+++ b/uptime_service_validation/coordinator/helper.py
@@ -369,7 +369,7 @@ def getExistingNodes(conn, logger):
 
 
 if __name__ == "__main__":
-    a = datetime(2023, 11, 6, 15, 35, 47, 630499)
+    a = datetime(2023, 11, 6, 15, 35, 47, 630)
     b = a + timedelta(minutes=5)
     result = getTimeBatches(a, b, 10)
     print(result)

--- a/uptime_service_validation/coordinator/server.py
+++ b/uptime_service_validation/coordinator/server.py
@@ -106,6 +106,7 @@ def setUpValidatorProcesses(time_intervals, logging, worker_image, worker_tag):
             os.environ.get("AWS_KEYSPACE"),
             f"{datetime_formatter(mini_batch[0])}",
             f"{datetime_formatter(mini_batch[1])}",
+            "--no-check",
         ]
         # command = [
         #     "delegation-verify",

--- a/uptime_service_validation/coordinator/server.py
+++ b/uptime_service_validation/coordinator/server.py
@@ -80,6 +80,7 @@ def setUpValidatorProcesses(time_intervals, logging, worker_image, worker_tag):
         command = [
             "docker",
             "run",
+            "--privileged",
             "-it",
             "--network",
             "host",


### PR DESCRIPTION
This pr makes it possible to run coordinator in a test environment. That means that stateless_verifier is not run as a separate pods, but rather in a subprocesses on the same machine. In order to activate this mode an optional env variable needs to be set `TEST_ENV=1`.

Additionally following changes were made:
 - many small fixes to make coordinator run (mostly typos, missing params etc.)
 - adding `invoke` tasks to create and initialized database (it may conveniently use to create config for e2e test)
 - readme updates explaining configuration in detail.