### PR TITLE
PM-1379 address SettingWithCopyWarning warning in logs

### DIFF
--- a/uptime_service_validation/coordinator/coordinator.py
+++ b/uptime_service_validation/coordinator/coordinator.py
@@ -256,6 +256,7 @@ def process_statehash_df(db, batch, state_hash_df, verification_time):
     db.insert_statehash_results(shortlisted_state_hash_df)
 
     if not point_record_df.empty:
+        point_record_df = point_record_df.copy()
         point_record_df.loc[:, "amount"] = 1
         point_record_df.loc[:, "created_at"] = datetime.now(timezone.utc)
         point_record_df.loc[:, "bot_log_id"] = bot_log_id


### PR DESCRIPTION
This change should get rid of the warning in coordinator log:

```
/home/piotr/code/mf/uptime-service-validation/uptime_service_validation/coordinator/coordinator.py:259: SettingWithCopyWarning: 
A value is trying to be set on a copy of a slice from a DataFrame.
Try using .loc[row_indexer,col_indexer] = value instead

See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy
  point_record_df.loc[:, "amount"] = 1
/home/piotr/code/mf/uptime-service-validation/uptime_service_validation/coordinator/coordinator.py:260: SettingWithCopyWarning: 
A value is trying to be set on a copy of a slice from a DataFrame.
Try using .loc[row_indexer,col_indexer] = value instead

See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy
  point_record_df.loc[:, "created_at"] = datetime.now(timezone.utc)
/home/piotr/code/mf/uptime-service-validation/uptime_service_validation/coordinator/coordinator.py:261: SettingWithCopyWarning: 
A value is trying to be set on a copy of a slice from a DataFrame.
Try using .loc[row_indexer,col_indexer] = value instead

See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy
  point_record_df.loc[:, "bot_log_id"] = bot_log_id
```