### PR TITLE
PM-1421 Fix uptime scoreboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 This repository is home for Validator/Coordinator component for Mina Delegation Program.
 This component is responsible for taking submissions data gathered by [uptime-service-backend](https://github.com/MinaFoundation/uptime-service-backend) and running validation against them using [stateless-verification-tool](https://github.com/MinaProtocol/mina/pull/14593). Next, based on these validation results, the Coordinator builds its own database containing uptime score.
 
+**Important note:** If block producer submits at least one valid submission within the validation batch, it will be granted one point. There is a table `points_summary` that is instrumental for calculating scores. It is updated by a database trigger on every insert to the `points` table. While `points` table 
+holds one point for each valid submission, the `points_summary` holds only one point if at least one submission happened in the batch. This is crucial for keeping correct score percentage.
 
 ## Getting Started
 

--- a/uptime_service_validation/coordinator/helper.py
+++ b/uptime_service_validation/coordinator/helper.py
@@ -236,6 +236,11 @@ class DB:
             score_till_time,
             uptime_days,
         )
+        # update the scores
+        # Note that points_summary table is updated by the database trigger
+        # on every insert to the points table.
+        # It holds one record per block producer per batch if they submitted any valid submissions within the batch.
+        # Scores are calculated based on the points_summary table.
         sql = """with vars  (snapshot_date, start_date) as( values (%s AT TIME ZONE 'UTC',
                         (%s - interval '%s' day) AT TIME ZONE 'UTC')
               )

--- a/uptime_service_validation/coordinator/helper.py
+++ b/uptime_service_validation/coordinator/helper.py
@@ -250,7 +250,7 @@ class DB:
               )
               , scores as (
                 select p.node_id, count(p.bot_log_id) bp_points
-                from points p join bot_logs b on p.bot_log_id =b.id, epochs
+                from points_summary p join bot_logs b on p.bot_log_id =b.id, epochs
                 where b.batch_start_epoch >= start_epoch and b.batch_end_epoch <= end_epoch
                 group by 1
               )

--- a/uptime_service_validation/coordinator/helper.py
+++ b/uptime_service_validation/coordinator/helper.py
@@ -231,7 +231,11 @@ class DB:
 
     def update_scoreboard(self, score_till_time, uptime_days=30):
         "Update the block producer scores."
-        self.logger.info("updateScoreboard  start ")
+        self.logger.info(
+            "updateScoreboard  start (score_till_time: %s, uptime_days: %s) ",
+            score_till_time,
+            uptime_days,
+        )
         sql = """with vars  (snapshot_date, start_date) as( values (%s AT TIME ZONE 'UTC',
                         (%s - interval '%s' day) AT TIME ZONE 'UTC')
               )
@@ -242,12 +246,12 @@ class DB:
               , b_logs as(
                 select (count(1) ) as surveys
                 from bot_logs b , epochs e
-                where b.batch_start_epoch >= start_epoch and  b.batch_end_epoch <= end_epoch
+                where b.batch_start_epoch >= start_epoch and  b.batch_end_epoch <= end_epoch and b.files_processed > 0
               )
               , scores as (
                 select p.node_id, count(p.bot_log_id) bp_points
                 from points p join bot_logs b on p.bot_log_id =b.id, epochs
-                where b.batch_start_epoch >= start_epoch and  b.batch_end_epoch <= end_epoch
+                where b.batch_start_epoch >= start_epoch and b.batch_end_epoch <= end_epoch
                 group by 1
               )
               , final_scores as (

--- a/uptime_service_validation/database/create_tables.sql
+++ b/uptime_service_validation/database/create_tables.sql
@@ -35,7 +35,7 @@ CREATE TABLE IF NOT EXISTS nodes (
 	block_producer_key TEXT,
 	updated_at TIMESTAMPTZ(6),
 	score INT,
-	score_percent NUMERIC(10,2),
+	score_percent NUMERIC(5,2),
 	discord_id TEXT,
 	email_id TEXT,
 	application_status BOOLEAN
@@ -69,7 +69,7 @@ CREATE TABLE IF NOT EXISTS score_history (
 	node_id INT,
 	score_at TIMESTAMP(6), 
 	score INT, 
-	score_percent NUMERIC(10,2),
+	score_percent NUMERIC(5,2),
 	CONSTRAINT fk_nodes
 		FOREIGN KEY(node_id) 
 		REFERENCES nodes(id)

--- a/uptime_service_validation/database/create_tables.sql
+++ b/uptime_service_validation/database/create_tables.sql
@@ -41,6 +41,7 @@ CREATE TABLE IF NOT EXISTS nodes (
 	application_status BOOLEAN
 );
 
+-- The points table stores the points of each node for each validated submission.
 CREATE TABLE IF NOT EXISTS points (
 	id SERIAL PRIMARY KEY,
 	file_name TEXT,
@@ -74,3 +75,48 @@ CREATE TABLE IF NOT EXISTS score_history (
 		REFERENCES nodes(id)
 );
 CREATE UNIQUE INDEX IF NOT EXISTS uq_sh_node_score_at ON score_history USING btree (node_id, score_at);
+
+-- Table creation for points_summary
+-- The points_summary table aggregates data related to node scoring.
+-- It is designed to hold a unique combination of bot_log_id and node_id.
+-- This allows us to ensure that each node's contribution within a single batch
+-- is counted once, preventing the final score from exceeding 100% in cases
+-- where block producers may send more than one valid submission in a batch.
+-- It is used by `update_scoreboard` function to update the final_score of each node.
+CREATE TABLE IF NOT EXISTS points_summary (
+    bot_log_id INT NOT NULL,
+    node_id INT NOT NULL
+);
+
+-- Unique index for points_summary
+-- A unique index on bot_log_id and node_id ensures that the pair is unique within the table.
+-- This supports the trigger function's role in preventing duplicate summary entries
+-- for the same bot_log and node combination.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_ps_bot_log_node ON points_summary USING btree (bot_log_id, node_id);
+
+-- Trigger function definition for updating the points_summary
+-- This function, fn_update_point_summary, is a trigger function that responds to insert operations.
+-- When a new point is inserted, this function attempts to insert a corresponding entry into
+-- the points_summary table. If an entry with the same bot_log_id and node_id already exists,
+-- it does nothing (avoids duplicate entries), ensuring that each node's score is calculated
+-- correctly for a batch and that the final_score does not exceed 100%.
+CREATE OR REPLACE FUNCTION fn_update_point_summary()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $function$
+BEGIN
+    INSERT INTO points_summary(bot_log_id, node_id)
+    VALUES(NEW.bot_log_id, NEW.node_id)
+    ON CONFLICT (bot_log_id, node_id) DO NOTHING;
+    RETURN new;
+END;
+$function$;
+
+-- Trigger for points_summary update
+-- This trigger, trg_after_insert_points, is set to fire after a new record is inserted into the points table.
+-- For each new row, it calls the fn_update_point_summary function to maintain the points_summary.
+-- This mechanism is crucial for ensuring that each node's score within a batch is accounted for accurately.
+CREATE OR REPLACE TRIGGER trg_after_insert_points
+AFTER INSERT ON points
+FOR EACH ROW
+EXECUTE FUNCTION fn_update_point_summary();


### PR DESCRIPTION
This PR adds `points_summary` table to the schema and related function and trigger that updates it whenever `points` table is updated. `Points_summary`, contrary to `points`,  holds only 1 record per node if there was at least 1 valid submission within the batch. This way we can count valid score percentage <0,100>% for the `UPTIME_DAYS_FOR_SCORE` period, no matter what value is set for `SURVEY_INTERVAL_MINUTES`, which determines the number of batches within  `UPTIME_DAYS_FOR_SCORE` period.