### PR TITLE
PM-1495 Submissions by submitter for analysis

### DIFF
--- a/uptime_service_validation/coordinator/helper.py
+++ b/uptime_service_validation/coordinator/helper.py
@@ -325,6 +325,46 @@ class DB:
         self.logger.info("update_application_status  end ")
         return 0
 
+    def insert_submissions(self, submissions):
+        """Insert a list of Submission objects into the submissions_by_submitter table."""
+        self.logger.info(
+            "insert_submissions  start (submissions: %s)", len(submissions)
+        )
+        insert_query = """
+            INSERT INTO submissions_by_submitter (
+                submitted_at_date, submitted_at, submitter, remote_addr, block_hash, 
+                state_hash, parent, height, slot, validation_error, verified
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+        """
+        values = [
+            (
+                submission.submitted_at_date,
+                submission.submitted_at,
+                submission.submitter,
+                submission.remote_addr,
+                submission.block_hash,
+                submission.state_hash,
+                submission.parent,
+                submission.height,
+                submission.slot,
+                submission.validation_error,
+                submission.verified,
+            )
+            for submission in submissions
+        ]
+
+        cursor = self.connection.cursor()
+        try:
+            extras.execute_batch(cursor, insert_query, values)
+        except (Exception, psycopg2.DatabaseError) as error:
+            self.logger.error("Error inserting submissions: %s", error)
+            cursor.close()
+            return -1
+        finally:
+            cursor.close()
+        self.logger.info("insert_submissions  end")
+        return 0
+
 
 def get_contact_details_from_spreadsheet():
     "Get the contact details of the block producers from the Google spreadsheet."

--- a/uptime_service_validation/database/create_tables.sql
+++ b/uptime_service_validation/database/create_tables.sql
@@ -76,6 +76,28 @@ CREATE TABLE IF NOT EXISTS score_history (
 );
 CREATE UNIQUE INDEX IF NOT EXISTS uq_sh_node_score_at ON score_history USING btree (node_id, score_at);
 
+-- Table submission_by_submitter is used to store the submissions made by each submitter.
+-- This table is useful to analyze the submissions made by each submitter no matter the status of the submission.
+-- It is a light copy of the Cassandra submissions table exluding some of the data (like snark_work, raw_block, etc.)
+CREATE TABLE IF NOT EXISTS submissions_by_submitter (
+    id SERIAL PRIMARY KEY,
+    submitted_at_date DATE NOT NULL,
+    submitted_at TIMESTAMP NOT NULL,
+    submitter TEXT NOT NULL,
+    remote_addr TEXT,
+    block_hash TEXT,
+    state_hash TEXT,
+    parent TEXT,
+    height INTEGER,
+    slot INTEGER,
+    validation_error TEXT,
+    verified BOOLEAN
+);
+-- Create an index on submitter and submitted_at_date for quick lookups by submitter
+CREATE INDEX idx_submitter_date ON submissions_by_submitter (submitter, submitted_at_date);
+-- Create an index on submitter and submitted_at for queries that might need to sort or filter by exact timestamps
+CREATE INDEX idx_submitter_datetime ON submissions_by_submitter (submitter, submitted_at DESC);
+
 -- Table creation for points_summary
 -- The points_summary table aggregates data related to node scoring.
 -- It is designed to hold a unique combination of bot_log_id and node_id.


### PR DESCRIPTION
This PR adds additional table `submissions_by_submitter` into coordinator database and a mechanism where on each processing batch all submissions that fall into the batch are copied into this table. This way we have useful data at hand for analyzing in case when there are queries about the lost points.

Coordinator database with this additional table `submissions_by_submitter` will be backend database for Submission Report Web app -> https://github.com/MinaFoundation/submission-report.