### PR TITLE
PM-1592 Create bot log when no subs processed

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -86,7 +86,7 @@ def init_database(ctx, batch_end_epoch=None, mins_ago=None, override_empty=False
 
     if should_insert:
         processing_time = 0
-        files_processed = 0
+        files_processed = -1  # -1 indicates that this is initialization
         file_timestamps = datetime.fromtimestamp(batch_end_epoch, timezone.utc)
         batch_start_epoch = batch_end_epoch
 

--- a/uptime_service_validation/coordinator/coordinator.py
+++ b/uptime_service_validation/coordinator/coordinator.py
@@ -383,8 +383,16 @@ def process(db, state):
             state.retry_batch()
             return
     else:
-        # new bot log id hasn't been created, so proceed with the old one
-        bot_log_id = state.batch.bot_log_id
+        # process_statehash_df not processed so new bot log id hasn't been created,
+        # creating a new bot log id entry with 0 submissions processed
+        values = (
+            0,  # submissions processed
+            state.batch.end_time,
+            state.batch.start_time.timestamp(),
+            state.batch.end_time.timestamp(),
+            timer.duration.total_seconds(),
+        )
+        bot_log_id = db.create_bot_log(values)
         logging.info("Finished processing data from table.")
     try:
         db.update_scoreboard(

--- a/uptime_service_validation/coordinator/helper.py
+++ b/uptime_service_validation/coordinator/helper.py
@@ -279,7 +279,7 @@ class DB:
               , b_logs as(
                 select (count(1) ) as surveys
                 from bot_logs b , epochs e
-                where b.batch_start_epoch >= start_epoch and  b.batch_end_epoch <= end_epoch and b.files_processed > 0
+                where b.batch_start_epoch >= start_epoch and  b.batch_end_epoch <= end_epoch and b.files_processed > -1
               )
               , scores as (
                 select p.node_id, count(p.bot_log_id) bp_points


### PR DESCRIPTION
Addressing #50.
>The problem is that when there are no submissions created in the particular batch, the, so called, bot_log is not created. This is a logic mistake, as bot-logs are taken into consideration when calculating scores. Basically the issue is that when in such circumstances coordinator is restarted it re-starts it’s work from the last non-empty batch, whereas it should start from the last processed batch.

>The fix is to create_bot_log with files_processed = 0 on batch where there were no submissions. It is probably highly unlikely situation in production environment not to have submissions in the batch, however it is consistent that we should include such batch in the scoring calculations.