### PR TITLE
PM-2039 Support custom nodepool

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ These environment variables control the program's runtime:
 Configuration related to infra/operations.
 
 - `SPREAD_MAX_SKEW` - The degree of the spread of Stateless Verification workers among the nodes, see: [`maxSkew`](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#spread-constraint-definition). Default: `1`.
+- `K8S_NODE_POOL` (optional) - Name of the node pool to spin pods on.
 
 ### Stateless Verification Tool Configuration
 

--- a/uptime_service_validation/coordinator/server.py
+++ b/uptime_service_validation/coordinator/server.py
@@ -235,6 +235,10 @@ def setUpValidatorPods(time_intervals, logging, worker_image, worker_tag):
             volume_mounts=[auth_volume_mount],
         )
 
+        nodepool = os.environ.get("K8S_NODE_POOL")
+        node_selector = {"karpenter.sh/nodepool": nodepool} if nodepool else None
+        tolerations = [{"key": "karpenter.sh/nodepool", "operator": "Exists"}] if nodepool else None
+
         pod_annotations = {"karpenter.sh/do-not-disrupt": "true"}
         pod_labels = {"job-group-name": job_group_name}
 
@@ -250,6 +254,8 @@ def setUpValidatorPods(time_intervals, logging, worker_image, worker_tag):
                         annotations=pod_annotations, labels=pod_labels
                     ),
                     spec=client.V1PodSpec(
+                        node_selector=node_selector,
+                        tolerations=tolerations,
                         topology_spread_constraints=[
                             client.V1TopologySpreadConstraint(
                                 max_skew=int(os.environ.get("SPREAD_MAX_SKEW", "1")),


### PR DESCRIPTION
This PR implements `K8S_NODE_POOL` environment variable to allow to spin pods on a specific node pool.

This change be tested on staging cluster using the existing nodepool `mina-delegation-verify`.

This change will **not** need any update of the helm chart. The specific nodepool can be created in the gitops repository for the need of the deployment (given a cluster), and the environment variable can be set in mean time. I will open the PR for production when we are ready.